### PR TITLE
Narrow ignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+test/closet/syntax.js

--- a/lib/index.js
+++ b/lib/index.js
@@ -135,9 +135,9 @@ internals.tryToRequire = (path) => {
     try {
         return require(path);
     }
-    catch (ignoreErr) {
+    catch (err) {
 
-        Hoek.assert(ignoreErr.code === 'MODULE_NOT_FOUND', ignoreErr);
+        Hoek.assert(err.code === 'MODULE_NOT_FOUND', err);
 
         return undefined;
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -136,6 +136,9 @@ internals.tryToRequire = (path) => {
         return require(path);
     }
     catch (ignoreErr) {
+
+        Hoek.assert(ignoreErr.code === 'MODULE_NOT_FOUND', ignoreErr);
+
         return undefined;
     }
 };

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "test"
   },
   "scripts": {
-    "test": "lab -a code -t 100 -L",
-    "coveralls": "lab -r lcov | coveralls"
+    "test": "lab -a code -t 100 -L test/index.js",
+    "coveralls": "lab -r lcov | coveralls test/index.js"
   },
   "repository": {
     "type": "git",

--- a/test/closet/syntax.js
+++ b/test/closet/syntax.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = (instance, options) => {
+
+    instance.insideFunc = 'instance;
+    options.insideFunc = 'options';
+
+    return {
+        func: 'value'
+    };
+};

--- a/test/index.js
+++ b/test/index.js
@@ -562,4 +562,37 @@ describe('Haute', () => {
         });
     });
 
+    it('requires a file with a syntax error.', (done) => {
+
+        const calledWith = {};
+
+        const instance = {
+            callThis: function (arg) {
+
+                calledWith.arg = arg;
+                calledWith.length = arguments.length;
+            }
+        };
+
+        const options = {};
+
+        const manifest = [{
+            method: 'callThis',
+            place: 'syntax'
+        }];
+
+        const thrower = function () {
+
+            Haute(dirname, manifest)(instance, options, (ignoreErr) => {
+
+                done(new Error('Should have had an error'));
+            });
+        };
+
+        expect(
+            thrower
+        ).to.throw();
+        done();
+    });
+
 });


### PR DESCRIPTION
Ensure that we only ignore `MODULE_NOT_FOUND` errors when requiring. Resolves #4 
