### PR TITLE
v3: run() and call(), recursive directory handling, include and exclude, custom methods, meta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 
 node_js:
   - "8"
-  - "9"
+  - "10"
   - "node"
 
 after_script: "npm run coveralls"

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,17 +7,22 @@ const RequireDir = require('require-dir');
 
 const internals = {};
 
-exports.using = (dirname, instanceName, manifest) => {
-
-    Hoek.assert(internals.isDirectory(dirname), `Directory "${dirname}" does not exist.`);
-    Hoek.assert(typeof instanceName === 'string', 'You must specify a name for the instance.  It will be used to generate meaningful error messages.');
+exports.using = () => {
 
     return {
-        calls() {
+        calls(instanceName, manifest) {
+
+            Hoek.assert(typeof instanceName === 'string', 'You must specify a name for the instance.  It will be used to generate meaningful error messages.');
+
+            const dirnames = Hoek.unique(manifest.map(({ dirname }) => dirname));
+            dirnames.forEach((dirname) => {
+
+                Hoek.assert(internals.isDirectory(dirname), `Directory "${dirname}" does not exist.`);
+            });
 
             return manifest.reduce((collector, bone) => {
 
-                const place = Path.join(dirname, bone.place);
+                const place = Path.join(bone.dirname, bone.place);
 
                 // Resolve arguments
 
@@ -52,6 +57,7 @@ exports.using = (dirname, instanceName, manifest) => {
                 if (bone.list && Array.isArray(argGroups)) {
                     return collector.concat(
                         argGroups.map((args, i) => ({
+                            instanceName,
                             file: dirFiles ? fullPlaces[i] : fullPlace,
                             place: dirFiles ? relativePlaces[i] : bone.place,
                             useFilename: dirFiles ? useFilenames[i] : null,
@@ -59,12 +65,14 @@ exports.using = (dirname, instanceName, manifest) => {
                             method: bone.method,
                             signature: bone.signature,
                             args,
-                            list: bone.list
+                            list: bone.list,
+                            meta: bone.meta
                         }))
                     );
                 }
 
                 return collector.concat({
+                    instanceName,
                     file: fullPlace,
                     place: bone.place,
                     useFilename: null,
@@ -72,7 +80,8 @@ exports.using = (dirname, instanceName, manifest) => {
                     method: bone.method,
                     signature: bone.signature,
                     args: argGroups,
-                    list: bone.list
+                    list: bone.list,
+                    meta: bone.meta
                 });
             }, []);
         },
@@ -87,7 +96,7 @@ exports.using = (dirname, instanceName, manifest) => {
                     args = args(instance, ...options);
 
                     if (call.list && !call.dirFile && Array.isArray(args)) {
-                        const subCalls = args.map((arg) => Object.assign({}, call, { args: arg, evaluated: true }));
+                        const subCalls = args.map((arg) => ({ ...call, args: arg, evaluated: true }));
 
                         for (let i = 0; i < subCalls.length; ++i) {
                             await makeCall(subCalls[i]);
@@ -135,9 +144,9 @@ exports.using = (dirname, instanceName, manifest) => {
                 const context = Hoek.reach(instance, base || false);
                 const method = Hoek.reach(instance, call.method);
 
-                Hoek.assert(typeof method === 'function', `"${call.method}" is not a method on the passed ${instanceName}.`);
+                Hoek.assert(typeof method === 'function', `"${call.method}" is not a method on the passed ${call.instanceName}.`);
 
-                await internals.callMethod(method, context, appliableArgs, call, instanceName);
+                await internals.callMethod(method, context, appliableArgs, call);
             };
 
             for (let i = 0; i < calls.length; ++i) {
@@ -149,19 +158,19 @@ exports.using = (dirname, instanceName, manifest) => {
 
 internals.isClass = (func) => (/^\s*class\s/).test(func.toString());
 
-internals.callMethod = async (method, context, appliableArgs, call, instanceName) => {
+internals.callMethod = async (method, context, appliableArgs, call) => {
 
     try {
         await method.apply(context, appliableArgs);
     }
     catch (err) {
-        throw internals.tagError(err, call, instanceName);
+        throw internals.tagError(err, call);
     }
 };
 
-internals.tagError = (error, call, instanceName) => {
+internals.tagError = (error, call) => {
 
-    const message = `${instanceName}.${call.method}() called by haute using ${call.file}`;
+    const message = `${call.instanceName}.${call.method}() called by haute using ${call.file}`;
     error.message = message + (error.message ? ': ' + error.message : '');
 
     return error;

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,153 +7,149 @@ const RequireDir = require('require-dir');
 
 const internals = {};
 
-exports.using = () => {
+exports.calls = (instanceName, manifest) => {
 
-    return {
-        calls(instanceName, manifest) {
+    Hoek.assert(typeof instanceName === 'string', 'You must specify a name for the instance.  It will be used to generate meaningful error messages.');
 
-            Hoek.assert(typeof instanceName === 'string', 'You must specify a name for the instance.  It will be used to generate meaningful error messages.');
+    const dirnames = Hoek.unique(manifest.map(({ dirname }) => dirname));
+    dirnames.forEach((dirname) => {
 
-            const dirnames = Hoek.unique(manifest.map(({ dirname }) => dirname));
-            dirnames.forEach((dirname) => {
+        Hoek.assert(internals.isDirectory(dirname), `Directory "${dirname}" does not exist.`);
+    });
 
-                Hoek.assert(internals.isDirectory(dirname), `Directory "${dirname}" does not exist.`);
+    return manifest.reduce((collector, bone) => {
+
+        const place = Path.join(bone.dirname, bone.place);
+
+        // Resolve arguments
+
+        let argGroups = internals.tryToRequire(place);
+        const dirFiles = (typeof argGroups === 'undefined') && bone.list && internals.isDirectory(place);
+        const fullPlace = (typeof argGroups !== 'undefined') ? require.resolve(place) : '';
+        const fullPlaces = [];
+        const relativePlaces = [];
+        const useFilenames = [];
+
+        if (dirFiles) {
+
+            const requiredDir = RequireDir(place);
+
+            argGroups = Object.keys(requiredDir).map((name) => {
+
+                useFilenames.push(bone.useFilename && ((v) => bone.useFilename(name, v)));
+                relativePlaces.push(Path.join(bone.place, name));
+                fullPlaces.push(require.resolve(Path.join(place, name)));
+
+                return requiredDir[name];
             });
+        }
 
-            return manifest.reduce((collector, bone) => {
+        // No arguments to use, skip
+        if (typeof argGroups === 'undefined') {
+            return collector;
+        }
 
-                const place = Path.join(bone.dirname, bone.place);
+        // Queue-up the API calls
 
-                // Resolve arguments
-
-                let argGroups = internals.tryToRequire(place);
-                const dirFiles = (typeof argGroups === 'undefined') && bone.list && internals.isDirectory(place);
-                const fullPlace = (typeof argGroups !== 'undefined') ? require.resolve(place) : '';
-                const fullPlaces = [];
-                const relativePlaces = [];
-                const useFilenames = [];
-
-                if (dirFiles) {
-
-                    const requiredDir = RequireDir(place);
-
-                    argGroups = Object.keys(requiredDir).map((name) => {
-
-                        useFilenames.push(bone.useFilename && ((v) => bone.useFilename(name, v)));
-                        relativePlaces.push(Path.join(bone.place, name));
-                        fullPlaces.push(require.resolve(Path.join(place, name)));
-
-                        return requiredDir[name];
-                    });
-                }
-
-                // No arguments to use, skip
-                if (typeof argGroups === 'undefined') {
-                    return collector;
-                }
-
-                // Queue-up the API calls
-
-                if (bone.list && Array.isArray(argGroups)) {
-                    return collector.concat(
-                        argGroups.map((args, i) => ({
-                            instanceName,
-                            file: dirFiles ? fullPlaces[i] : fullPlace,
-                            place: dirFiles ? relativePlaces[i] : bone.place,
-                            useFilename: dirFiles ? useFilenames[i] : null,
-                            dirFile: dirFiles,
-                            method: bone.method,
-                            signature: bone.signature,
-                            args,
-                            list: bone.list,
-                            meta: bone.meta
-                        }))
-                    );
-                }
-
-                return collector.concat({
+        if (bone.list && Array.isArray(argGroups)) {
+            return collector.concat(
+                argGroups.map((args, i) => ({
                     instanceName,
-                    file: fullPlace,
-                    place: bone.place,
-                    useFilename: null,
+                    file: dirFiles ? fullPlaces[i] : fullPlace,
+                    place: dirFiles ? relativePlaces[i] : bone.place,
+                    useFilename: dirFiles ? useFilenames[i] : null,
                     dirFile: dirFiles,
                     method: bone.method,
                     signature: bone.signature,
-                    args: argGroups,
+                    args,
                     list: bone.list,
                     meta: bone.meta
-                });
-            }, []);
-        },
-        async run(calls, instance, ...options) {
+                }))
+            );
+        }
 
-            const makeCall = async (call) => {
+        return collector.concat({
+            instanceName,
+            file: fullPlace,
+            place: bone.place,
+            useFilename: null,
+            dirFile: dirFiles,
+            method: bone.method,
+            signature: bone.signature,
+            args: argGroups,
+            list: bone.list,
+            meta: bone.meta
+        });
+    }, []);
+};
 
-                let args = call.args;
+exports.run = async (calls, instance, ...options) => {
 
-                if (typeof args === 'function' && !internals.isClass(args) && !call.evaluated) {
+    const makeCall = async (call) => {
 
-                    args = args(instance, ...options);
+        let args = call.args;
 
-                    if (call.list && !call.dirFile && Array.isArray(args)) {
-                        const subCalls = args.map((arg) => ({ ...call, args: arg, evaluated: true }));
+        if (typeof args === 'function' && !internals.isClass(args) && !call.evaluated) {
 
-                        for (let i = 0; i < subCalls.length; ++i) {
-                            await makeCall(subCalls[i]);
-                        }
+            args = args(instance, ...options);
 
-                        return;
-                    }
+            if (call.list && !call.dirFile && Array.isArray(args)) {
+                const subCalls = args.map((arg) => ({ ...call, args: arg, evaluated: true }));
+
+                for (let i = 0; i < subCalls.length; ++i) {
+                    await makeCall(subCalls[i]);
                 }
 
-                if (call.useFilename) {
-                    args = call.useFilename(args);
-                }
-
-                if (typeof args === 'undefined') {
-                    return;
-                }
-
-                let appliableArgs;
-
-                if (call.signature) {
-
-                    appliableArgs = call.signature.reduce((collector, arg) => {
-
-                        const optional = /^\[.+\]$/.test(arg);
-
-                        if (optional) {
-                            arg = arg.slice(1, -1); // [argName] -> argName
-                            if (args.hasOwnProperty(arg)) {
-                                collector.push(args[arg]);
-                            }
-                        }
-                        else {
-                            collector.push(args[arg]);
-                        }
-
-                        return collector;
-                    }, []);
-
-                }
-                else {
-                    appliableArgs = [args];
-                }
-
-                const base = call.method.split('.').slice(0, -1).join('.');
-                const context = Hoek.reach(instance, base || false);
-                const method = Hoek.reach(instance, call.method);
-
-                Hoek.assert(typeof method === 'function', `"${call.method}" is not a method on the passed ${call.instanceName}.`);
-
-                await internals.callMethod(method, context, appliableArgs, call);
-            };
-
-            for (let i = 0; i < calls.length; ++i) {
-                await makeCall(calls[i]);
+                return;
             }
         }
+
+        if (call.useFilename) {
+            args = call.useFilename(args);
+        }
+
+        if (typeof args === 'undefined') {
+            return;
+        }
+
+        let appliableArgs;
+
+        if (call.signature) {
+
+            appliableArgs = call.signature.reduce((collector, arg) => {
+
+                const optional = /^\[.+\]$/.test(arg);
+
+                if (optional) {
+                    arg = arg.slice(1, -1); // [argName] -> argName
+                    if (args.hasOwnProperty(arg)) {
+                        collector.push(args[arg]);
+                    }
+                }
+                else {
+                    collector.push(args[arg]);
+                }
+
+                return collector;
+            }, []);
+
+        }
+        else {
+            appliableArgs = [args];
+        }
+
+        const base = call.method.split('.').slice(0, -1).join('.');
+        const context = Hoek.reach(instance, base || false);
+        const method = Hoek.reach(instance, call.method);
+
+        Hoek.assert(typeof method === 'function', `"${call.method}" is not a method on the passed ${call.instanceName}.`);
+
+        await internals.callMethod(method, context, appliableArgs, call);
     };
+
+    for (let i = 0; i < calls.length; ++i) {
+        await makeCall(calls[i]);
+    }
 };
 
 internals.isClass = (func) => (/^\s*class\s/).test(func.toString());

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,129 +12,137 @@ exports.using = (dirname, instanceName, manifest) => {
     Hoek.assert(internals.isDirectory(dirname), `Directory "${dirname}" does not exist.`);
     Hoek.assert(typeof instanceName === 'string', 'You must specify a name for the instance.  It will be used to generate meaningful error messages.');
 
-    // Main routine run on particular instance
-    return async (instance, options) => {
+    return {
+        calls() {
 
-        const calls = manifest.reduce((collector, bone) => {
+            return manifest.reduce((collector, bone) => {
 
-            const place = Path.join(dirname, bone.place);
+                const place = Path.join(dirname, bone.place);
 
-            // Resolve arguments
+                // Resolve arguments
 
-            let argGroups = internals.tryToRequire(place);
-            const dirFiles = (typeof argGroups === 'undefined') && bone.list && internals.isDirectory(place);
-            const fullPlace = (typeof argGroups !== 'undefined') ? require.resolve(place) : '';
-            const fullPlaces = [];
-            const useFilenames = [];
+                let argGroups = internals.tryToRequire(place);
+                const dirFiles = (typeof argGroups === 'undefined') && bone.list && internals.isDirectory(place);
+                const fullPlace = (typeof argGroups !== 'undefined') ? require.resolve(place) : '';
+                const fullPlaces = [];
+                const relativePlaces = [];
+                const useFilenames = [];
 
-            if (dirFiles) {
+                if (dirFiles) {
 
-                const requiredDir = RequireDir(place);
+                    const requiredDir = RequireDir(place);
 
-                argGroups = Object.keys(requiredDir).map((name) => {
+                    argGroups = Object.keys(requiredDir).map((name) => {
 
-                    useFilenames.push(bone.useFilename && ((v) => bone.useFilename(name, v)));
-                    fullPlaces.push(require.resolve(Path.join(place, name)));
+                        useFilenames.push(bone.useFilename && ((v) => bone.useFilename(name, v)));
+                        relativePlaces.push(Path.join(bone.place, name));
+                        fullPlaces.push(require.resolve(Path.join(place, name)));
 
-                    return requiredDir[name];
+                        return requiredDir[name];
+                    });
+                }
+
+                // No arguments to use, skip
+                if (typeof argGroups === 'undefined') {
+                    return collector;
+                }
+
+                // Queue-up the API calls
+
+                if (bone.list && Array.isArray(argGroups)) {
+                    return collector.concat(
+                        argGroups.map((args, i) => ({
+                            file: dirFiles ? fullPlaces[i] : fullPlace,
+                            place: dirFiles ? relativePlaces[i] : bone.place,
+                            useFilename: dirFiles ? useFilenames[i] : null,
+                            dirFile: dirFiles,
+                            method: bone.method,
+                            signature: bone.signature,
+                            args,
+                            list: bone.list
+                        }))
+                    );
+                }
+
+                return collector.concat({
+                    file: fullPlace,
+                    place: bone.place,
+                    useFilename: null,
+                    dirFile: dirFiles,
+                    method: bone.method,
+                    signature: bone.signature,
+                    args: argGroups,
+                    list: bone.list
                 });
-            }
+            }, []);
+        },
+        async run(calls, instance, ...options) {
 
-            // No arguments to use, skip
-            if (typeof argGroups === 'undefined') {
-                return collector;
-            }
+            const makeCall = async (call) => {
 
-            // Queue-up the API calls
+                let args = call.args;
 
-            if (bone.list && Array.isArray(argGroups)) {
-                return collector.concat(
-                    argGroups.map((args, i) => ({
-                        file: dirFiles ? fullPlaces[i] : fullPlace,
-                        useFilename: dirFiles ? useFilenames[i] : null,
-                        dirFile: dirFiles,
-                        method: bone.method,
-                        signature: bone.signature,
-                        args,
-                        list: bone.list
-                    }))
-                );
-            }
+                if (typeof args === 'function' && !internals.isClass(args) && !call.evaluated) {
 
-            return collector.concat({
-                file: fullPlace,
-                useFilename: null,
-                dirFile: dirFiles,
-                method: bone.method,
-                signature: bone.signature,
-                args: argGroups,
-                list: bone.list
-            });
-        }, []);
+                    args = args(instance, ...options);
 
-        const makeCall = async (call) => {
+                    if (call.list && !call.dirFile && Array.isArray(args)) {
+                        const subCalls = args.map((arg) => Object.assign({}, call, { args: arg, evaluated: true }));
 
-            let args = call.args;
+                        for (let i = 0; i < subCalls.length; ++i) {
+                            await makeCall(subCalls[i]);
+                        }
 
-            if (typeof args === 'function' && !internals.isClass(args) && !call.evaluated) {
-                args = args(instance, options);
-
-                if (call.list && !call.dirFile && Array.isArray(args)) {
-                    const subCalls = args.map((arg) => Object.assign({}, call, { args: arg, evaluated: true }));
-
-                    for (let i = 0; i < subCalls.length; ++i) {
-                        await makeCall(subCalls[i]);
+                        return;
                     }
+                }
 
+                if (call.useFilename) {
+                    args = call.useFilename(args);
+                }
+
+                if (typeof args === 'undefined') {
                     return;
                 }
-            }
 
-            if (call.useFilename) {
-                args = call.useFilename(args);
-            }
+                let appliableArgs;
 
-            if (typeof args === 'undefined') {
-                return;
-            }
+                if (call.signature) {
 
-            let appliableArgs;
+                    appliableArgs = call.signature.reduce((collector, arg) => {
 
-            if (call.signature) {
+                        const optional = /^\[.+\]$/.test(arg);
 
-                appliableArgs = call.signature.reduce((collector, arg) => {
-
-                    const optional = /^\[.+\]$/.test(arg);
-
-                    if (optional) {
-                        arg = arg.slice(1, -1); // [argName] -> argName
-                        if (args.hasOwnProperty(arg)) {
+                        if (optional) {
+                            arg = arg.slice(1, -1); // [argName] -> argName
+                            if (args.hasOwnProperty(arg)) {
+                                collector.push(args[arg]);
+                            }
+                        }
+                        else {
                             collector.push(args[arg]);
                         }
-                    }
-                    else {
-                        collector.push(args[arg]);
-                    }
 
-                    return collector;
-                }, []);
+                        return collector;
+                    }, []);
 
+                }
+                else {
+                    appliableArgs = [args];
+                }
+
+                const base = call.method.split('.').slice(0, -1).join('.');
+                const context = Hoek.reach(instance, base || false);
+                const method = Hoek.reach(instance, call.method);
+
+                Hoek.assert(typeof method === 'function', `"${call.method}" is not a method on the passed ${instanceName}.`);
+
+                await internals.callMethod(method, context, appliableArgs, call, instanceName);
+            };
+
+            for (let i = 0; i < calls.length; ++i) {
+                await makeCall(calls[i]);
             }
-            else {
-                appliableArgs = [args];
-            }
-
-            const base = call.method.split('.').slice(0, -1).join('.');
-            const context = Hoek.reach(instance, base || false);
-            const method = Hoek.reach(instance, call.method);
-
-            Hoek.assert(typeof method === 'function', `"${call.method}" is not a method on the passed ${instanceName}.`);
-
-            await internals.callMethod(method, context, appliableArgs, call, instanceName);
-        };
-
-        for (let i = 0; i < calls.length; ++i) {
-            await makeCall(calls[i]);
         }
     };
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,7 @@ exports.calls = (instanceName, manifest) => {
             };
 
             RequireDir(module, place, {
-                recurse: bone.recurse !== false,    // Defaults to true
+                recurse: bone.recursive !== false,    // Defaults to true
                 exclude: relativize(bone.exclude),
                 include: relativize(bone.include),
                 visit: (value, path) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 const Fs = require('fs');
 const Path = require('path');
 const Hoek = require('hoek');
-const RequireDir = require('require-dir');
+const RequireDir = require('require-directory');
 
 const internals = {};
 
@@ -32,15 +32,39 @@ exports.calls = (instanceName, manifest) => {
 
         if (dirFiles) {
 
-            const requiredDir = RequireDir(place);
+            argGroups = [];
 
-            argGroups = Object.keys(requiredDir).map((name) => {
+            const relativize = (fn) => {
 
-                useFilenames.push(bone.useFilename && ((v) => bone.useFilename(name, v)));
-                relativePlaces.push(Path.join(bone.place, name));
-                fullPlaces.push(require.resolve(Path.join(place, name)));
+                if (!fn) {
+                    return fn;
+                }
 
-                return requiredDir[name];
+                if (typeof fn === 'function') {
+                    return (path, file) => fn(Path.basename(file, Path.extname(file)), Path.relative(place, path));
+                }
+
+                const regex = fn;   // Should be a regex
+
+                Hoek.assert(regex instanceof RegExp, 'Options to `include` and `exclude` options must be either a function or a RegExp.');
+
+                return (path) => regex.test(Path.relative(place, path));
+            };
+
+            RequireDir(module, place, {
+                recurse: bone.recurse !== false,    // Defaults to true
+                exclude: relativize(bone.exclude),
+                include: relativize(bone.include),
+                visit: (value, path) => {
+
+                    const name = Path.basename(path, Path.extname(path));
+                    const relPath = Path.relative(place, path);
+
+                    argGroups.push(value);
+                    useFilenames.push(bone.useFilename && ((v) => bone.useFilename(v, name, relPath)));
+                    relativePlaces.push(Path.join(bone.place, name));
+                    fullPlaces.push(path);
+                }
             });
         }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -162,13 +162,14 @@ exports.run = async (calls, instance, ...options) => {
             appliableArgs = [args];
         }
 
-        const base = call.method.split('.').slice(0, -1).join('.');
+        const methodIsFunc = (typeof call.method === 'function');
+        const base = methodIsFunc ? null : call.method.split('.').slice(0, -1).join('.');
         const context = Hoek.reach(instance, base || false);
-        const method = Hoek.reach(instance, call.method);
+        const method = methodIsFunc ? call.method : Hoek.reach(instance, call.method);
 
         Hoek.assert(typeof method === 'function', `"${call.method}" is not a method on the passed ${call.instanceName}.`);
 
-        await internals.callMethod(method, context, appliableArgs, call);
+        await internals.callMethod(method, context, appliableArgs, options, call, methodIsFunc);
     };
 
     for (let i = 0; i < calls.length; ++i) {
@@ -178,20 +179,28 @@ exports.run = async (calls, instance, ...options) => {
 
 internals.isClass = (func) => (/^\s*class\s/).test(func.toString());
 
-internals.callMethod = async (method, context, appliableArgs, call) => {
+internals.callMethod = async (method, context, appliableArgs, options, call, callAsFunction) => {
 
     try {
-        await method.apply(context, appliableArgs);
+        if (callAsFunction) {
+            await method(context, ...options, ...appliableArgs);
+        }
+        else {
+            await method.apply(context, appliableArgs);
+        }
     }
     catch (err) {
-        throw internals.tagError(err, call);
+        throw internals.tagError(err, call, callAsFunction);
     }
 };
 
-internals.tagError = (error, call) => {
+internals.tagError = (error, call, callAsFunction) => {
 
-    const message = `${call.instanceName}.${call.method}() called by haute using ${call.file}`;
-    error.message = message + (error.message ? ': ' + error.message : '');
+    const message = callAsFunction ?
+        `Custom "${call.place}" method called by haute using ${call.file}` :
+        `${call.instanceName}.${call.method}() called by haute using ${call.file}`;
+
+    error.message = message + (error.message ? `: ${error.message}` : '');
 
     return error;
 };

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "code": "5.x.x",
-    "coveralls": "2.x.x",
-    "lab": "15.x.x"
+    "coveralls": "3.x.x",
+    "lab": "16.x.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/devinivy/haute#readme",
   "dependencies": {
     "hoek": "5.x.x",
-    "require-dir": "1.x.x"
+    "require-directory": "2.x.x"
   },
   "devDependencies": {
     "code": "5.x.x",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/devinivy/haute#readme",
   "dependencies": {
     "hoek": "5.x.x",
-    "require-dir": "0.3.x"
+    "require-dir": "1.x.x"
   },
   "devDependencies": {
     "code": "5.x.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haute",
-  "version": "2.0.0",
+  "version": "3.0.0-rc.1",
   "description": "directory structure as code",
   "main": "lib/index.js",
   "engines": {

--- a/test/closet/recursive/item.js
+++ b/test/closet/recursive/item.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/test/closet/recursive/one/a/item-one.js
+++ b/test/closet/recursive/one/a/item-one.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/test/closet/recursive/one/a/item-two.js
+++ b/test/closet/recursive/one/a/item-two.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/test/closet/recursive/one/b/item-one.js
+++ b/test/closet/recursive/one/b/item-one.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/test/closet/recursive/two/a/item-one.js
+++ b/test/closet/recursive/two/a/item-one.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/test/closet/recursive/two/item-one.js
+++ b/test/closet/recursive/two/item-one.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/test/index.js
+++ b/test/index.js
@@ -877,7 +877,7 @@ describe('Haute', () => {
 
         const manifest = [{
             method: 'callThis',
-            place: 'recurse',
+            place: 'recursive',
             list: true,
             useFilename: (value, filename, path) => {
 
@@ -912,9 +912,9 @@ describe('Haute', () => {
 
         const manifest = [{
             method: 'callThis',
-            place: 'recurse',
+            place: 'recursive',
             list: true,
-            recurse: true,
+            recursive: true,
             useFilename: (value, filename, path) => {
 
                 value.filename = filename;
@@ -948,9 +948,9 @@ describe('Haute', () => {
 
         const manifest = [{
             method: 'callThis',
-            place: 'recurse',
+            place: 'recursive',
             list: true,
-            recurse: false,
+            recursive: false,
             useFilename: (value, filename, path) => {
 
                 value.filename = filename;
@@ -980,9 +980,9 @@ describe('Haute', () => {
 
         const manifest = [{
             method: 'callThis',
-            place: 'recurse',
+            place: 'recursive',
             list: true,
-            recurse: true,
+            recursive: true,
             exclude: (filename, path, ...others) => {
 
                 excludeArgs.push([filename, path, ...others]);
@@ -1028,9 +1028,9 @@ describe('Haute', () => {
 
         const manifest = [{
             method: 'callThis',
-            place: 'recurse',
+            place: 'recursive',
             list: true,
-            recurse: true,
+            recursive: true,
             exclude: /-one/,
             useFilename: (value, filename, path) => {
 
@@ -1062,9 +1062,9 @@ describe('Haute', () => {
 
         const manifest = [{
             method: 'callThis',
-            place: 'recurse',
+            place: 'recursive',
             list: true,
-            recurse: true,
+            recursive: true,
             include: (filename, path, ...others) => {
 
                 excludeArgs.push([filename, path, ...others]);
@@ -1110,9 +1110,9 @@ describe('Haute', () => {
 
         const manifest = [{
             method: 'callThis',
-            place: 'recurse',
+            place: 'recursive',
             list: true,
-            recurse: true,
+            recursive: true,
             include: /-one/,
             useFilename: (value, filename, path) => {
 

--- a/test/index.js
+++ b/test/index.js
@@ -18,12 +18,22 @@ const internals = {};
 
 describe('Haute', () => {
 
-    const dirname = `${__dirname}/closet`;
+    const closetDir = `${__dirname}/closet`;
+    const using = (dirname, instanceName, manifest) => {
 
-    it('throws when provided a bad directory path.', () => {
+        return async (...args) => {
+
+            const calls = Haute.calls(instanceName, manifest.map((item) => ({ ...item, dirname })));
+            await Haute.run(calls, ...args);
+        };
+    };
+
+    it('throws when provided a bad directory path.', async () => {
 
         const badPath = `${__dirname}/bad-path`;
-        expect(() => Haute.using(badPath, 'instance', [])).to.throw(`Directory "${badPath}" does not exist.`);
+        const haute = using(badPath, 'instance', [{}]);
+
+        await expect(haute({})).to.reject(`Directory "${badPath}" does not exist.`);
     });
 
     it('calls with argument from a plain file.', async () => {
@@ -43,7 +53,7 @@ describe('Haute', () => {
             place: 'file'
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, {});
+        await using(closetDir, 'instance', manifest)(instance, {});
 
         expect(calledWith.arg).to.equal({ file: 'value' });
         expect(calledWith.length).to.equal(1);
@@ -87,7 +97,7 @@ describe('Haute', () => {
             }
         ];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, {});
+        await using(closetDir, 'instance', manifest)(instance, {});
 
         expect(calledWith).to.equal([
             { arg: { file: 'value' }, length: 1 },
@@ -111,7 +121,7 @@ describe('Haute', () => {
             place: 'file'
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, {});
+        await using(closetDir, 'instance', manifest)(instance, {});
 
         expect(instance.context).to.equal(true);
     });
@@ -136,7 +146,7 @@ describe('Haute', () => {
             place: 'file'
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, {});
+        await using(closetDir, 'instance', manifest)(instance, {});
 
         expect(calledWith.arg).to.equal({ file: 'value' });
         expect(calledWith.length).to.equal(1);
@@ -161,7 +171,7 @@ describe('Haute', () => {
         }];
 
         // No options passed
-        await Haute.using(dirname, 'instance', manifest)(instance);
+        await using(closetDir, 'instance', manifest)(instance);
 
         expect(calledWith.arg).to.equal({ file: 'value' });
         expect(calledWith.length).to.equal(1);
@@ -193,7 +203,7 @@ describe('Haute', () => {
             place: 'file'
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, {});
+        await using(closetDir, 'instance', manifest)(instance, {});
 
         expect(calledWith.arg).to.equal({ file: 'value' });
         expect(calledWith.waited).to.equal(true);
@@ -226,7 +236,7 @@ describe('Haute', () => {
             place: 'file'
         }];
 
-        await expect(Haute.using(dirname, 'instance', manifest)(instance, {})).to.reject(/:\)$/);
+        await expect(using(closetDir, 'instance', manifest)(instance, {})).to.reject(/:\)$/);
 
         expect(calledWith.arg).to.equal({ file: 'value' });
         expect(calledWith.waited).to.equal(true);
@@ -252,7 +262,7 @@ describe('Haute', () => {
             signature: ['sigOne', 'sigTwo']
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, {});
+        await using(closetDir, 'instance', manifest)(instance, {});
 
         expect(calledWith.sigOne).to.equal('valueOne');
         expect(calledWith.sigTwo).to.equal('valueTwo');
@@ -277,7 +287,7 @@ describe('Haute', () => {
             signature: ['[sigOne]', 'sigTwo']
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, {});
+        await using(closetDir, 'instance', manifest)(instance, {});
 
         expect(calledWith.sigTwo).to.equal('valueTwo');
         expect(calledWith.length).to.equal(1);
@@ -302,7 +312,7 @@ describe('Haute', () => {
             signature: ['[sigOne]', 'sigTwo']
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance);
+        await using(closetDir, 'instance', manifest)(instance);
 
         expect(calledWith.sigOne).to.equal('valueOne');
         expect(calledWith.sigTwo).to.equal('valueTwo');
@@ -326,7 +336,7 @@ describe('Haute', () => {
             place: 'json-file'
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, {});
+        await using(closetDir, 'instance', manifest)(instance, {});
 
         expect(calledWith.arg).to.equal({ json: 'value' });
         expect(calledWith.length).to.equal(1);
@@ -349,7 +359,7 @@ describe('Haute', () => {
             list: true
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, {});
+        await using(closetDir, 'instance', manifest)(instance, {});
 
         expect(calledWith).to.equal([
             { arg: { listOne: 'valueOne' }, length: 1 },
@@ -374,7 +384,7 @@ describe('Haute', () => {
             list: true
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, {});
+        await using(closetDir, 'instance', manifest)(instance, {});
 
         expect(calledWith).to.equal([
             { arg: { listOne: 'valueOne' }, length: 1 }
@@ -400,7 +410,7 @@ describe('Haute', () => {
             list: true
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, options);
+        await using(closetDir, 'instance', manifest)(instance, options);
 
         expect(instance.insideFunc).to.equal('instance');
         expect(options.insideFunc).to.equal('options');
@@ -429,7 +439,7 @@ describe('Haute', () => {
             list: true
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, options);
+        await using(closetDir, 'instance', manifest)(instance, options);
 
         expect(calledWith).to.have.length(3);
         expect(calledWith[0].arg).to.shallow.equal(ClassAsDirItem);
@@ -471,7 +481,7 @@ describe('Haute', () => {
             }
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, {});
+        await using(closetDir, 'instance', manifest)(instance, {});
 
         expect(calledWith).to.have.length(3);
         expect(calledWith[0].arg.prototype).to.be.instanceof(ClassAsDirItem);
@@ -498,7 +508,7 @@ describe('Haute', () => {
             place: 'dir-index'
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, {});
+        await using(closetDir, 'instance', manifest)(instance, {});
 
         expect(calledWith.arg).to.equal({ dirIndex: 'value' });
         expect(calledWith.length).to.equal(1);
@@ -521,7 +531,7 @@ describe('Haute', () => {
             place: 'deeper/file'
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, {});
+        await using(closetDir, 'instance', manifest)(instance, {});
 
         expect(calledWith.arg).to.equal({ deeper: 'value' });
         expect(calledWith.length).to.equal(1);
@@ -543,7 +553,7 @@ describe('Haute', () => {
             place: 'doesnt-exist'
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, {});
+        await using(closetDir, 'instance', manifest)(instance, {});
 
         expect(called).to.equal(false);
     });
@@ -577,7 +587,7 @@ describe('Haute', () => {
             }
         ];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, options);
+        await using(closetDir, 'instance', manifest)(instance, options);
 
         expect(propValue).to.equal('lazy');
     });
@@ -601,7 +611,7 @@ describe('Haute', () => {
             place: 'func'
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, options);
+        await using(closetDir, 'instance', manifest)(instance, options);
 
         expect(calledWith.arg).to.equal({ func: 'value' });
         expect(calledWith.length).to.equal(1);
@@ -627,7 +637,7 @@ describe('Haute', () => {
             place: 'func-empty'
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, options);
+        await using(closetDir, 'instance', manifest)(instance, options);
 
         expect(called).to.equal(false);
         expect(instance.insideFunc).to.equal('instance');
@@ -653,7 +663,7 @@ describe('Haute', () => {
             place: 'class'
         }];
 
-        await Haute.using(dirname, 'instance', manifest)(instance, options);
+        await using(closetDir, 'instance', manifest)(instance, options);
 
         expect(calledWith.arg).to.shallow.equal(ClassAsFile);
         expect(calledWith.length).to.equal(1);
@@ -670,7 +680,7 @@ describe('Haute', () => {
             place: 'bad-syntax'
         }];
 
-        const haute = Haute.using(dirname, 'instance', manifest);
+        const haute = using(closetDir, 'instance', manifest);
 
         await expect(haute(instance)).to.reject(SyntaxError, /unexpected token/i);
     });
@@ -686,7 +696,7 @@ describe('Haute', () => {
             place: 'bad-require'
         }];
 
-        const haute = Haute.using(dirname, 'instance', manifest);
+        const haute = using(closetDir, 'instance', manifest);
 
         await expect(haute(instance)).to.reject(/Cannot find module/);
     });
@@ -705,9 +715,9 @@ describe('Haute', () => {
             place: 'file'
         }];
 
-        const haute = Haute.using(dirname, 'instance', manifest);
+        const haute = using(closetDir, 'instance', manifest);
 
-        await expect(haute(instance)).to.reject(`instance.callThis() called by haute using ${Path.join(dirname, 'file.js')}: Runtime oopsie!`);
+        await expect(haute(instance)).to.reject(`instance.callThis() called by haute using ${Path.join(closetDir, 'file.js')}: Runtime oopsie!`);
     });
 
     it('tags async runtime errors with calling info.', async () => {
@@ -726,9 +736,9 @@ describe('Haute', () => {
             place: 'file'
         }];
 
-        const haute = Haute.using(dirname, 'instance', manifest);
+        const haute = using(closetDir, 'instance', manifest);
 
-        await expect(haute(instance)).to.reject(`instance.callThis() called by haute using ${Path.join(dirname, 'file.js')}: Runtime oopsie!`);
+        await expect(haute(instance)).to.reject(`instance.callThis() called by haute using ${Path.join(closetDir, 'file.js')}: Runtime oopsie!`);
     });
 
     it('tags runtime errors without existing messages.', async () => {
@@ -747,9 +757,9 @@ describe('Haute', () => {
             place: 'file'
         }];
 
-        const haute = Haute.using(dirname, 'instance', manifest);
+        const haute = using(closetDir, 'instance', manifest);
 
-        await expect(haute(instance)).to.reject(`instance.callThis() called by haute using ${Path.join(dirname, 'file.js')}`);
+        await expect(haute(instance)).to.reject(`instance.callThis() called by haute using ${Path.join(closetDir, 'file.js')}`);
     });
 
     it('tags runtime errors with correct path in single list file.', async () => {
@@ -769,9 +779,9 @@ describe('Haute', () => {
             list: true
         }];
 
-        const haute = Haute.using(dirname, 'instance', manifest);
+        const haute = using(closetDir, 'instance', manifest);
 
-        await expect(haute(instance)).to.reject(`instance.callThis() called by haute using ${Path.join(dirname, 'list-as-file.js')}`);
+        await expect(haute(instance)).to.reject(`instance.callThis() called by haute using ${Path.join(closetDir, 'list-as-file.js')}`);
     });
 
     it('tags runtime errors with correct path in listed directory files.', async () => {
@@ -796,8 +806,8 @@ describe('Haute', () => {
             useFilename: (filename) => filename
         }];
 
-        const haute = Haute.using(dirname, 'instance', manifest);
+        const haute = using(closetDir, 'instance', manifest);
 
-        await expect(haute(instance, {})).to.reject(`instance.callThis() called by haute using ${Path.join(dirname, 'list-as-dir-files', 'plain-item.js')}`);
+        await expect(haute(instance, {})).to.reject(`instance.callThis() called by haute using ${Path.join(closetDir, 'list-as-dir-files', 'plain-item.js')}`);
     });
 });


### PR DESCRIPTION
There are a handful of features and changes in here!

 - `run()` and `call()` decouple generating the function calls from running them, which allows consumers to pre-process calls before running them.
 - recursive directory handling allows haute to discover files nested deeply within a given `place`.
 - `include` and `exclude` allow one to programmatically include or exclude files in a directory.
 - custom methods allow manifests to specify a function rather than a method name, and that function will be passed the `instance` and `options` in order to make the proper method calls. 
 - `meta` is just a nice, standard place to put meta-info about a given manifest item that carries over into the generated calls.