### PR TITLE
Support async function exports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - "8"
   - "10"
+  - "12"
   - "node"
 
 after_script: "npm run coveralls"

--- a/lib/index.js
+++ b/lib/index.js
@@ -117,7 +117,7 @@ exports.run = async (calls, instance, ...options) => {
 
         if (typeof args === 'function' && !internals.isClass(args) && !call.evaluated) {
 
-            args = args(instance, ...options);
+            args = await args(instance, ...options);
 
             if (call.list && !call.dirFile && Array.isArray(args)) {
                 const subCalls = args.map((arg) => ({ ...call, args: arg, evaluated: true }));

--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
   },
   "homepage": "https://github.com/devinivy/haute#readme",
   "dependencies": {
-    "@hapi/hoek": "6.x.x",
+    "@hapi/hoek": "8.x.x",
     "require-directory": "2.x.x"
   },
   "devDependencies": {
-    "@hapi/code": "5.x.x",
-    "@hapi/lab": "18.x.x",
+    "@hapi/code": "6.x.x",
+    "@hapi/lab": "20.x.x",
     "coveralls": "3.x.x"
   }
 }

--- a/test/closet/func-async.js
+++ b/test/closet/func-async.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = async (instance, options) => {
+
+    await new Promise((resolve) => setTimeout(resolve, 1));
+
+    instance.insideFunc = 'instance';
+    options.insideFunc = 'options';
+
+    return {
+        func: 'value'
+    };
+};

--- a/test/closet/list-func-async-as-file.js
+++ b/test/closet/list-func-async-as-file.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = async (instance, options) => {
+
+    await new Promise((resolve) => setTimeout(resolve, 1));
+
+    instance.insideFunc = 'instance';
+    options.insideFunc = 'options';
+
+    return [
+        {
+            listOne: 'valueOne'
+        },
+        {
+            listTwo: 'valueTwo'
+        },
+        () => ({                    // To ensure function evaluation does not recurse
+            listThree: 'valueThree'
+        })
+    ];
+};

--- a/test/index.js
+++ b/test/index.js
@@ -433,6 +433,40 @@ describe('Haute', () => {
         ]);
     });
 
+    it('calls with evaluated async function argument in list file.', async () => {
+
+        const calledWith = [];
+
+        const instance = {
+            callThis: function (arg) {
+
+                calledWith.push({ arg, length: arguments.length });
+            }
+        };
+
+        const options = {};
+
+        const manifest = [{
+            method: 'callThis',
+            place: 'list-func-async-as-file',
+            list: true
+        }];
+
+        await using(closetDir, 'instance', manifest)(instance, options);
+
+        expect(instance.insideFunc).to.equal('instance');
+        expect(options.insideFunc).to.equal('options');
+
+        const [one, two, three, ...others] = calledWith;
+
+        expect(others).to.have.length(0);
+        expect([one, two, { ...three, arg: three.arg() }]).to.equal([
+            { arg: { listOne: 'valueOne' }, length: 1 },
+            { arg: { listTwo: 'valueTwo' }, length: 1 },
+            { arg: { listThree: 'valueThree' }, length: 1 }
+        ]);
+    });
+
     it('calls with a list of arguments from multiple directory files.', async () => {
 
         const calledWith = [];
@@ -628,6 +662,33 @@ describe('Haute', () => {
         const manifest = [{
             method: 'callThis',
             place: 'func'
+        }];
+
+        await using(closetDir, 'instance', manifest)(instance, options);
+
+        expect(calledWith.arg).to.equal({ func: 'value' });
+        expect(calledWith.length).to.equal(1);
+        expect(instance.insideFunc).to.equal('instance');
+        expect(options.insideFunc).to.equal('options');
+    });
+
+    it('calls with evaluated async function argument in non-list.', async () => {
+
+        const calledWith = {};
+
+        const instance = {
+            callThis: function (arg) {
+
+                calledWith.arg = arg;
+                calledWith.length = arguments.length;
+            }
+        };
+
+        const options = {};
+
+        const manifest = [{
+            method: 'callThis',
+            place: 'func-async'
         }];
 
         await using(closetDir, 'instance', manifest)(instance, options);


### PR DESCRIPTION
Now you may export async functions:
```js
module.exports = async (instance, options) => {

    return { some: 'argument' };
};
```

Also includes some dependency upgrades.  Still supporting node v8 for now, so lab and code are one version behind current.