### PR TITLE
feat: support typescript files with default exports

### DIFF
--- a/.labrc.js
+++ b/.labrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+    coverage: true,
+    threshold: 100,
+    lint: true,
+    assert: '@hapi/code',
+    paths: ['test/index.js'],
+    globals: 'FinalizationRegistry,WeakRef'
+};

--- a/.labrc.js
+++ b/.labrc.js
@@ -4,5 +4,5 @@ module.exports = {
     lint: true,
     assert: '@hapi/code',
     paths: ['test/index.js'],
-    globals: 'FinalizationRegistry,WeakRef'
+    globals: 'FinalizationRegistry,WeakRef,AbortController,AbortSignal,EventTarget,Event,MessageChannel,MessagePort,MessageEvent,AggregateError'
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,10 @@ const Path = require('path');
 const Hoek = require('@hapi/hoek');
 const RequireDir = require('require-directory');
 
-const internals = {};
+const internals = {
+    // allows requiring .ts files for users who run with `ts-node`
+    extensions: ['js', 'ts', 'json', 'coffee']
+};
 
 exports.calls = (instanceName, manifest) => {
 
@@ -25,9 +28,10 @@ exports.calls = (instanceName, manifest) => {
 
         // Resolve arguments
 
-        let argGroups = internals.tryToRequire(place);
+        const resolvedPlace = internals.resolvePlace(place);
+        const fullPlace = resolvedPlace ? resolvedPlace.path : resolvedPlace;
+        let argGroups = resolvedPlace ? resolvedPlace.value : resolvedPlace;
         const dirFiles = (typeof argGroups === 'undefined') && bone.list && internals.isDirectory(place);
-        const fullPlace = (typeof argGroups !== 'undefined') ? require.resolve(place) : '';
         const fullPlaces = [];
         const relativePlaces = [];
         const useFilenames = [];
@@ -54,7 +58,7 @@ exports.calls = (instanceName, manifest) => {
             };
 
             RequireDir(module, place, {
-                extensions: ['ts'].concat(RequireDir.defaults.extensions), // allows requiring .ts files for users who run with `ts-node`
+                extensions: internals.extensions,
                 recurse: bone.recursive !== false,    // Defaults to true
                 exclude: relativize(bone.exclude),
                 include: relativize(bone.include),
@@ -222,10 +226,43 @@ internals.tagError = (error, call, callAsFunction) => {
     return error;
 };
 
+internals.resolvePlace = (place, extensionIdx = 0) => {
+
+    const ext = '.' + internals.extensions[extensionIdx];
+    const indexPath = Path.format({
+        dir: place,
+        name: 'index',
+        ext
+    });
+    const path = place + ext;
+
+    const indexValue = internals.tryToRequire(indexPath);
+    if (indexValue) {
+        return {
+            value: indexValue,
+            path: indexPath
+        };
+    }
+
+    const value = internals.tryToRequire(path);
+    if (!value) {
+        const nextExtensionIdx = extensionIdx + 1;
+        if (nextExtensionIdx < internals.extensions.length) {
+            return internals.resolvePlace(place, nextExtensionIdx);
+        }
+
+        return undefined;
+    }
+
+    return { value, path };
+};
+
 internals.tryToRequire = (path) => {
 
     try {
-        return require(path);
+        const value = require(path);
+
+        return internals.normalizeDefaultExport(value, Path.extname(path));
     }
     catch (err) {
         // Must be an error specifically from trying to require the passed (normalized) path

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,15 +54,17 @@ exports.calls = (instanceName, manifest) => {
             };
 
             RequireDir(module, place, {
+                extensions: ['ts'].concat(RequireDir.defaults.extensions), // allows requiring .ts files for users who run with `ts-node`
                 recurse: bone.recursive !== false,    // Defaults to true
                 exclude: relativize(bone.exclude),
                 include: relativize(bone.include),
                 visit: (value, path) => {
 
-                    const name = Path.basename(path, Path.extname(path));
+                    const ext = Path.extname(path);
+                    const name = Path.basename(path, ext);
                     const relPath = Path.relative(place, path);
 
-                    argGroups.push(value);
+                    argGroups.push(internals.normalizeDefaultExport(value, ext));
                     useFilenames.push(bone.useFilename && ((v) => bone.useFilename(v, name, relPath)));
                     relativePlaces.push(Path.join(bone.place, name));
                     fullPlaces.push(path);
@@ -177,6 +179,19 @@ exports.run = async (calls, instance, ...options) => {
     for (let i = 0; i < calls.length; ++i) {
         await makeCall(calls[i]);
     }
+};
+
+internals.normalizeDefaultExport = (value, ext) => {
+
+    if (!value.default) {
+        return value;
+    }
+
+    if (ext === '.ts') {
+        return value.default;
+    }
+
+    return value;
 };
 
 internals.isClass = (func) => (/^\s*class\s/).test(func.toString());

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "test": "test"
   },
   "scripts": {
-    "test": "lab -a @hapi/code -t 100 -L test/index.js",
-    "coveralls": "lab -r lcov test/index.js | coveralls"
+    "test": "lab",
+    "coveralls": "lab -r lcov | coveralls"
   },
   "repository": {
     "type": "git",

--- a/test/closet/module-files/common.js
+++ b/test/closet/module-files/common.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+    default: 'value',
+    file: 'commonjs'
+};

--- a/test/closet/module-files/typescript.ts
+++ b/test/closet/module-files/typescript.ts
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+    default: {
+        file: 'typescript'
+    }
+};

--- a/test/closet/validator-ts.ts
+++ b/test/closet/validator-ts.ts
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+    default: {
+        file: 'typescript-validator'
+    }
+};

--- a/test/index.js
+++ b/test/index.js
@@ -1211,4 +1211,28 @@ describe('Haute', () => {
             { arg: { filename: 'item-one', path: 'two/item-one.js' }, length: 1 }
         ]);
     });
+
+    it('can include typescript files in directories using default exports.', async () => {
+
+        const calledWith = [];
+
+        const instance = {
+            callThis: function (arg) {
+
+                calledWith.push({ arg, length: arguments.length });
+            }
+        };
+
+        const manifest = [{
+            method: 'callThis',
+            place: 'module-files',
+            list: true
+        }];
+
+        await using(closetDir, 'instance', manifest)(instance, {});
+        expect(calledWith).to.equal([
+            { arg: { file: 'commonjs', default: 'value' }, length: 1 },
+            { arg: { file: 'typescript' }, length: 1 }
+        ]);
+    });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1212,6 +1212,29 @@ describe('Haute', () => {
         ]);
     });
 
+    it('can include typescript files using default exports.', async () => {
+
+        const calledWith = [];
+
+        const instance = {
+            callThis: function (arg) {
+
+                calledWith.push({ arg, length: arguments.length });
+            }
+        };
+
+        const manifest = [{
+            method: 'callThis',
+            place: 'validator-ts',
+            list: true
+        }];
+
+        await using(closetDir, 'instance', manifest)(instance, {});
+        expect(calledWith).to.equal([
+            { arg: { file: 'typescript-validator' }, length: 1 }
+        ]);
+    });
+
     it('can include typescript files in directories using default exports.', async () => {
 
         const calledWith = [];


### PR DESCRIPTION
This PR is the simplest way to introduce TS via ts-node compatibility to haute. It adds the `ts` extension to the list of extensions `require-directory` is allowed to consider, and when the extension is `ts` and there's a `default` prop on the required file it'll use that default prop instead of the required file in order to be compatible with TS.

I attempted to add `.mjs` support as well, however that's going to be more involved and requires deprecating some of the node versions and changing from using `require()` to using `await import()` which likely necessitates a replacement for `require-directory` as well.

I'm a little worried about whether this'll pass CI for earlier node versions. Node 14 can require `.ts` files without exploding, but I'm counting on Travis to check the others.