### PR TITLE
v4: ESM support, stop-at-indexes support, drop node v8 and v10

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 test/closet/bad-syntax.js
+test/closet/type-is-module/**/*.js

--- a/.labrc.js
+++ b/.labrc.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {};
+
+(() => {
+    // We need a way to stash request.extensions['.js'] before it is overwritten
+    // by lab, for "type": "module" support, which we test in the test suite. The
+    // way lab overwrites it sidesteps the new ERR_REQUIRE_ESM error, and instead
+    // we get a syntax error for .js files that are ESM.
+    require.extensions['.js.stashed'] = require.extensions['.js'];
+})();

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 
 node_js:
-  - "8"
-  - "10"
   - "12"
   - "14"
   - "node"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2020 Devin Ivy and contributors
+Copyright (c) 2016-2021 Devin Ivy and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,6 @@ exports.calls = async (instanceName, manifest) => {
             };
 
             await Mo.walk(module, place, {
-                extensions: internals.extensions,
                 recursive: bone.recursive !== false,    // Defaults to true
                 stopAtIndexes: !!bone.stopAtIndexes,
                 exclude: relativize(bone.exclude),
@@ -202,8 +201,6 @@ exports.getDefaultExport = (exports_, path, type) => {
     return Mo.getDefaultExport(exports_, path, type);
 };
 
-internals.extensions = [...Mo.defaultExtensions, 'ts'];
-
 internals.isClass = (func) => (/^\s*class\s/).test(func.toString());
 
 internals.callMethod = async (method, context, appliableArgs, options, call, callAsFunction) => {
@@ -237,7 +234,7 @@ internals.isDirectory = (path) => {
     try {
         return Fs.statSync(path).isDirectory();
     }
-    catch (ignoreErr) {
+    catch {
         return false;
     }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,11 +3,11 @@
 const Fs = require('fs');
 const Path = require('path');
 const Hoek = require('@hapi/hoek');
-const RequireDir = require('require-directory');
+const Mo = require('mo-walk');
 
 const internals = {};
 
-exports.calls = (instanceName, manifest) => {
+exports.calls = async (instanceName, manifest) => {
 
     Hoek.assert(typeof instanceName === 'string', 'You must specify a name for the instance.  It will be used to generate meaningful error messages.');
 
@@ -19,16 +19,17 @@ exports.calls = (instanceName, manifest) => {
         Hoek.assert(internals.isDirectory(dirname), `Directory "${dirname}" does not exist.`);
     });
 
-    return manifest.reduce((collector, bone) => {
+    const collector = [];
 
+    for (const bone of manifest) {
         const place = Path.join(bone.dirname, bone.place);
 
         // Resolve arguments
 
-        const fullPlace = internals.tryToResolve(place);
+        const resolvedPlace = await Mo.tryToResolve(place);
 
-        let argGroups = (typeof fullPlace === 'undefined') ? undefined : exports.getDefaultExport(require(fullPlace), fullPlace);
-        const dirFiles = (typeof fullPlace === 'undefined') && bone.list && internals.isDirectory(place);
+        let argGroups = resolvedPlace ? exports.getDefaultExport(...resolvedPlace) : undefined;
+        const dirFiles = !resolvedPlace && bone.list && internals.isDirectory(place);
         const fullPlaces = [];
         const relativePlaces = [];
         const useFilenames = [];
@@ -54,9 +55,10 @@ exports.calls = (instanceName, manifest) => {
                 return (path) => regex.test(Path.relative(place, path));
             };
 
-            RequireDir(module, place, {
+            await Mo.walk(module, place, {
                 extensions: internals.extensions,
-                recurse: bone.recursive !== false,    // Defaults to true
+                recursive: bone.recursive !== false,    // Defaults to true
+                stopOnIndexes: false,
                 exclude: relativize(bone.exclude),
                 include: relativize(bone.include),
                 visit: (value, path) => {
@@ -73,17 +75,17 @@ exports.calls = (instanceName, manifest) => {
         }
 
         // No arguments to use, skip
-        if (typeof argGroups === 'undefined') {
-            return collector;
+        if (argGroups === undefined) {
+            continue;
         }
 
         // Queue-up the API calls
 
         if (bone.list && Array.isArray(argGroups)) {
-            return collector.concat(
-                argGroups.map((args, i) => ({
+            collector.push(
+                ...argGroups.map((args, i) => ({
                     instanceName,
-                    file: dirFiles ? fullPlaces[i] : fullPlace,
+                    file: dirFiles ? fullPlaces[i] : resolvedPlace[1],
                     place: dirFiles ? relativePlaces[i] : bone.place,
                     useFilename: dirFiles ? useFilenames[i] : null,
                     dirFile: dirFiles,
@@ -95,20 +97,23 @@ exports.calls = (instanceName, manifest) => {
                 }))
             );
         }
+        else {
+            collector.push({
+                instanceName,
+                file: resolvedPlace[1],
+                place: bone.place,
+                useFilename: null,
+                dirFile: dirFiles,
+                method: bone.method,
+                signature: bone.signature,
+                args: argGroups,
+                list: bone.list,
+                meta: bone.meta
+            });
+        }
+    }
 
-        return collector.concat({
-            instanceName,
-            file: fullPlace,
-            place: bone.place,
-            useFilename: null,
-            dirFile: dirFiles,
-            method: bone.method,
-            signature: bone.signature,
-            args: argGroups,
-            list: bone.list,
-            meta: bone.meta
-        });
-    }, []);
+    return collector;
 };
 
 exports.run = async (calls, instance, ...options) => {
@@ -183,7 +188,7 @@ exports.run = async (calls, instance, ...options) => {
 
 exports.getDefaultExport = (exports_, path) => {
 
-    if (Path.extname(path) === '.ts' &&
+    if (['.ts', '.mjs'].includes(Path.extname(path)) &&
         exports_ &&
         typeof exports_ === 'object' &&
         'default' in exports_) {
@@ -193,7 +198,7 @@ exports.getDefaultExport = (exports_, path) => {
     return exports_;
 };
 
-internals.extensions = [...RequireDir.defaults.extensions, 'ts'];
+internals.extensions = [...Mo.defaultExtensions, 'ts'];
 
 internals.isClass = (func) => (/^\s*class\s/).test(func.toString());
 
@@ -221,22 +226,6 @@ internals.tagError = (error, call, callAsFunction) => {
     error.message = message + (error.message ? `: ${error.message}` : '');
 
     return error;
-};
-
-internals.tryToResolve = (path) => {
-
-    try {
-        return require.resolve(path);
-    }
-    catch (err) {
-        // Must be an error specifically from trying to require the passed (normalized) path
-        // Note that these error messages are of the form "Cannot find module '${path}'".
-        // In node v12 this is followed by a "Require stack", which is why we're testing for
-        // the module path specifically wrapped in single quotes.
-        Hoek.assert(err.code === 'MODULE_NOT_FOUND', err);
-        Hoek.assert(~err.message.indexOf(`'${path}'`), err);
-        return undefined;
-    }
 };
 
 internals.isDirectory = (path) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,14 +19,19 @@ exports.calls = async (instanceName, manifest) => {
         Hoek.assert(internals.isDirectory(dirname), `Directory "${dirname}" does not exist.`);
     });
 
+    const defaultToESMByDir = new Map(await Promise.all(
+        dirnames.map(async (dirname) => [dirname, await Mo.getDefaultToESM(dirname)])
+    ));
+
     const collector = [];
 
     for (const bone of manifest) {
         const place = Path.join(bone.dirname, bone.place);
+        const defaultToESM = defaultToESMByDir.get(bone.dirname);
 
         // Resolve arguments
 
-        const resolvedPlace = await Mo.tryToResolve(place);
+        const resolvedPlace = await Mo.tryToResolve(place, { defaultToESM });
 
         let argGroups = resolvedPlace ? exports.getDefaultExport(...resolvedPlace) : undefined;
         const dirFiles = !resolvedPlace && bone.list && internals.isDirectory(place);
@@ -61,12 +66,13 @@ exports.calls = async (instanceName, manifest) => {
                 stopAtIndexes: !!bone.stopAtIndexes,
                 exclude: relativize(bone.exclude),
                 include: relativize(bone.include),
-                visit: (value, path) => {
+                defaultToESM,
+                visit: (value, path, _, type) => {
 
                     const name = Path.basename(path, Path.extname(path));
                     const relPath = Path.relative(place, path);
 
-                    argGroups.push(exports.getDefaultExport(value, path));
+                    argGroups.push(exports.getDefaultExport(value, path, type));
                     useFilenames.push(bone.useFilename && ((v) => bone.useFilename(v, name, relPath)));
                     relativePlaces.push(Path.join(bone.place, name));
                     fullPlaces.push(path);
@@ -186,16 +192,14 @@ exports.run = async (calls, instance, ...options) => {
     }
 };
 
-exports.getDefaultExport = (exports_, path) => {
+// Not recommended to use: maintaining for current major of haute-couture.
+exports.getDefaultExport = (exports_, path, type) => {
 
-    if (['.ts', '.mjs'].includes(Path.extname(path)) &&
-        exports_ &&
-        typeof exports_ === 'object' &&
-        'default' in exports_) {
-        return exports_.default;
+    if (!type && Path.extname(path) === '.mjs') {
+        type = 'esm';
     }
 
-    return exports_;
+    return Mo.getDefaultExport(exports_, path, type);
 };
 
 internals.extensions = [...Mo.defaultExtensions, 'ts'];

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,7 @@ exports.calls = async (instanceName, manifest) => {
             await Mo.walk(module, place, {
                 extensions: internals.extensions,
                 recursive: bone.recursive !== false,    // Defaults to true
-                stopOnIndexes: false,
+                stopAtIndexes: !!bone.stopAtIndexes,
                 exclude: relativize(bone.exclude),
                 include: relativize(bone.include),
                 visit: (value, path) => {

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "directory structure as code",
   "main": "lib/index.js",
   "engines": {
-    "node": ">=8"
+    "node": ">=12"
   },
   "directories": {
     "test": "test"
   },
   "scripts": {
-    "test": "lab -a @hapi/code -t 100 -L test/index.js -I 'AbortController,AbortSignal,EventTarget,Event,MessageChannel,MessagePort,MessageEvent,AggregateError,FinalizationRegistry,WeakRef'",
+    "test": "lab -a @hapi/code -t 100 -L test/index.js",
     "coveralls": "lab -r lcov test/index.js | coveralls"
   },
   "repository": {
@@ -30,12 +30,18 @@
   },
   "homepage": "https://github.com/devinivy/haute#readme",
   "dependencies": {
-    "@hapi/hoek": "8.x.x",
+    "@hapi/hoek": "9.x.x",
     "mo-walk": "1.x.x"
   },
   "devDependencies": {
-    "@hapi/code": "6.x.x",
-    "@hapi/lab": "20.x.x",
+    "@hapi/code": "8.x.x",
+    "@hapi/eslint-plugin": "*",
+    "@hapi/lab": "24.x.x",
     "coveralls": "3.x.x"
+  },
+  "eslintConfig": {
+    "extends": [
+      "plugin:@hapi/module"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/devinivy/haute#readme",
   "dependencies": {
     "@hapi/hoek": "8.x.x",
-    "require-directory": "2.x.x"
+    "mo-walk": "1.x.x"
   },
   "devDependencies": {
     "@hapi/code": "6.x.x",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/devinivy/haute#readme",
   "dependencies": {
     "@hapi/hoek": "9.x.x",
-    "mo-walk": "1.x.x"
+    "mo-walk": ">=1.1.0 <2"
   },
   "devDependencies": {
     "@hapi/code": "8.x.x",

--- a/test/closet/mjs/place-a.mjs
+++ b/test/closet/mjs/place-a.mjs
@@ -1,0 +1,1 @@
+export const a = 'value';

--- a/test/closet/mjs/place-b/index.mjs
+++ b/test/closet/mjs/place-b/index.mjs
@@ -1,0 +1,3 @@
+export default {
+    b: 'value'
+};

--- a/test/closet/mjs/place-c/item-one.mjs
+++ b/test/closet/mjs/place-c/item-one.mjs
@@ -1,0 +1,3 @@
+export default {
+    c: 'item-one'
+};

--- a/test/closet/mjs/place-c/item-three.js
+++ b/test/closet/mjs/place-c/item-three.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+    c: 'item-three'
+};

--- a/test/closet/mjs/place-c/item-two.mjs
+++ b/test/closet/mjs/place-c/item-two.mjs
@@ -1,0 +1,3 @@
+export default {
+    c: 'item-two'
+};

--- a/test/closet/mjs/place-d.mjs
+++ b/test/closet/mjs/place-d.mjs
@@ -1,0 +1,8 @@
+export default [
+    {
+        d: 'item-one'
+    },
+    {
+        d: 'item-two'
+    }
+];

--- a/test/closet/stop-at-indexes/a.js
+++ b/test/closet/stop-at-indexes/a.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/test/closet/stop-at-indexes/b.js
+++ b/test/closet/stop-at-indexes/b.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/test/closet/stop-at-indexes/c/e.js
+++ b/test/closet/stop-at-indexes/c/e.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/test/closet/stop-at-indexes/c/index.js
+++ b/test/closet/stop-at-indexes/c/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/test/closet/stop-at-indexes/d/f/g.js
+++ b/test/closet/stop-at-indexes/d/f/g.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/test/closet/stop-at-indexes/d/f/index.js
+++ b/test/closet/stop-at-indexes/d/f/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/test/closet/type-is-module/package.json
+++ b/test/closet/type-is-module/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }

--- a/test/closet/type-is-module/place-a.js
+++ b/test/closet/type-is-module/place-a.js
@@ -1,0 +1,1 @@
+export const a = 'value';

--- a/test/closet/type-is-module/place-b/index.js
+++ b/test/closet/type-is-module/place-b/index.js
@@ -1,0 +1,3 @@
+export default {
+    b: 'value'
+};

--- a/test/closet/type-is-module/place-c/item-one.js
+++ b/test/closet/type-is-module/place-c/item-one.js
@@ -1,0 +1,3 @@
+export default {
+    c: 'item-one'
+};

--- a/test/closet/type-is-module/place-c/item-three.json
+++ b/test/closet/type-is-module/place-c/item-three.json
@@ -1,0 +1,1 @@
+{  "c": "item-three"  }

--- a/test/closet/type-is-module/place-c/item-two.js
+++ b/test/closet/type-is-module/place-c/item-two.js
@@ -1,0 +1,3 @@
+export default {
+    c: 'item-two'
+};

--- a/test/closet/type-is-module/place-d.js
+++ b/test/closet/type-is-module/place-d.js
@@ -1,0 +1,8 @@
+export default [
+    {
+        d: 'item-one'
+    },
+    {
+        d: 'item-two'
+    }
+];

--- a/test/index.js
+++ b/test/index.js
@@ -19,11 +19,44 @@ const internals = {};
 describe('Haute', () => {
 
     const closetDir = `${__dirname}/closet`;
+
+    const byPath = (pathA, pathB) => {
+
+        const a = pathA.split(Path.sep);
+        const b = pathB.split(Path.sep);
+        const len = Math.max(a.length, b.length);
+
+        for (let i = 0; i < len; ++i) {
+            if (!(i in a)) {
+                return -1;
+            }
+            else if (!(i in b)) {
+                return 1;
+            }
+            else if (a[i] > b[i]) {
+                return 1;
+            }
+            else if (a[i] < b[i]) {
+                return -1;
+            }
+            else if (a.length < b.length) {
+                return -1;
+            }
+            else if (a.length > b.length) {
+                return 1;
+            }
+        }
+    };
+
+    const byExcludePath = (a, b) => byPath(a[1], b[1]);
+
+    const byArgPath = (a, b) => byPath(a.arg.path, b.arg.path);
+
     const using = (dirname, instanceName, manifest) => {
 
         return async (...args) => {
 
-            const calls = Haute.calls(instanceName, manifest.map((item) => ({ ...item, dirname })));
+            const calls = await Haute.calls(instanceName, manifest.map((item) => ({ ...item, dirname })));
             await Haute.run(calls, ...args);
         };
     };
@@ -969,13 +1002,13 @@ describe('Haute', () => {
 
         await using(closetDir, 'instance', manifest)(instance, {});
 
-        expect(calledWith).to.equal([
+        expect(calledWith.sort(byArgPath)).to.equal([
             { arg: { filename: 'item', path: 'item.js' }, length: 1 },
             { arg: { filename: 'item-one', path: 'one/a/item-one.js' }, length: 1 },
             { arg: { filename: 'item-two', path: 'one/a/item-two.js' }, length: 1 },
             { arg: { filename: 'item-one', path: 'one/b/item-one.js' }, length: 1 },
-            { arg: { filename: 'item-one', path: 'two/a/item-one.js' }, length: 1 },
-            { arg: { filename: 'item-one', path: 'two/item-one.js' }, length: 1 }
+            { arg: { filename: 'item-one', path: 'two/item-one.js' }, length: 1 },
+            { arg: { filename: 'item-one', path: 'two/a/item-one.js' }, length: 1 }
         ]);
     });
 
@@ -1005,13 +1038,13 @@ describe('Haute', () => {
 
         await using(closetDir, 'instance', manifest)(instance, {});
 
-        expect(calledWith).to.equal([
+        expect(calledWith.sort(byArgPath)).to.equal([
             { arg: { filename: 'item', path: 'item.js' }, length: 1 },
             { arg: { filename: 'item-one', path: 'one/a/item-one.js' }, length: 1 },
             { arg: { filename: 'item-two', path: 'one/a/item-two.js' }, length: 1 },
             { arg: { filename: 'item-one', path: 'one/b/item-one.js' }, length: 1 },
-            { arg: { filename: 'item-one', path: 'two/a/item-one.js' }, length: 1 },
-            { arg: { filename: 'item-one', path: 'two/item-one.js' }, length: 1 }
+            { arg: { filename: 'item-one', path: 'two/item-one.js' }, length: 1 },
+            { arg: { filename: 'item-one', path: 'two/a/item-one.js' }, length: 1 }
         ]);
     });
 
@@ -1079,16 +1112,16 @@ describe('Haute', () => {
 
         await using(closetDir, 'instance', manifest)(instance, {});
 
-        expect(excludeArgs).to.equal([
+        expect(excludeArgs.sort(byExcludePath)).to.equal([
             ['item', 'item.js'],
             ['item-one', 'one/a/item-one.js'],
             ['item-two', 'one/a/item-two.js'],
             ['item-one', 'one/b/item-one.js'],
-            ['item-one', 'two/a/item-one.js'],
-            ['item-one', 'two/item-one.js']
+            ['item-one', 'two/item-one.js'],
+            ['item-one', 'two/a/item-one.js']
         ]);
 
-        expect(calledWith).to.equal([
+        expect(calledWith.sort(byArgPath)).to.equal([
             { arg: { filename: 'item', path: 'item.js' }, length: 1 },
             { arg: { filename: 'item-one', path: 'one/b/item-one.js' }, length: 1 },
             { arg: { filename: 'item-one', path: 'two/item-one.js' }, length: 1 }
@@ -1161,16 +1194,16 @@ describe('Haute', () => {
 
         await using(closetDir, 'instance', manifest)(instance, {});
 
-        expect(excludeArgs).to.equal([
+        expect(excludeArgs.sort(byExcludePath)).to.equal([
             ['item', 'item.js'],
             ['item-one', 'one/a/item-one.js'],
             ['item-two', 'one/a/item-two.js'],
             ['item-one', 'one/b/item-one.js'],
-            ['item-one', 'two/a/item-one.js'],
-            ['item-one', 'two/item-one.js']
+            ['item-one', 'two/item-one.js'],
+            ['item-one', 'two/a/item-one.js']
         ]);
 
-        expect(calledWith).to.equal([
+        expect(calledWith.sort(byArgPath)).to.equal([
             { arg: { filename: 'item-one', path: 'one/a/item-one.js' }, length: 1 },
             { arg: { filename: 'item-two', path: 'one/a/item-two.js' }, length: 1 },
             { arg: { filename: 'item-one', path: 'two/a/item-one.js' }, length: 1 }
@@ -1204,11 +1237,11 @@ describe('Haute', () => {
 
         await using(closetDir, 'instance', manifest)(instance, {});
 
-        expect(calledWith).to.equal([
+        expect(calledWith.sort(byArgPath)).to.equal([
             { arg: { filename: 'item-one', path: 'one/a/item-one.js' }, length: 1 },
             { arg: { filename: 'item-one', path: 'one/b/item-one.js' }, length: 1 },
-            { arg: { filename: 'item-one', path: 'two/a/item-one.js' }, length: 1 },
-            { arg: { filename: 'item-one', path: 'two/item-one.js' }, length: 1 }
+            { arg: { filename: 'item-one', path: 'two/item-one.js' }, length: 1 },
+            { arg: { filename: 'item-one', path: 'two/a/item-one.js' }, length: 1 }
         ]);
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1245,6 +1245,79 @@ describe('Haute', () => {
         ]);
     });
 
+    it('does not stop at indexes by default.', async () => {
+
+        const calledWith = [];
+
+        const instance = {
+            callThis: function (arg) {
+
+                calledWith.push({ arg, length: arguments.length });
+            }
+        };
+
+        const manifest = [{
+            method: 'callThis',
+            place: 'stop-at-indexes',
+            list: true,
+            recursive: true,
+            useFilename: (value, filename, path) => {
+
+                value.filename = filename;
+                value.path = path;
+                return value;
+            }
+        }];
+
+        await using(closetDir, 'instance', manifest)(instance, {});
+
+        expect(calledWith.sort(byArgPath)).to.equal([
+            { arg: { filename: 'a', path: 'a.js' }, length: 1 },
+            { arg: { filename: 'b', path: 'b.js' }, length: 1 },
+            { arg: { filename: 'e', path: 'c/e.js' }, length: 1 },
+            { arg: { filename: 'index', path: 'c/index.js' }, length: 1 },
+            { arg: { filename: 'e', path: 'd/e.js' }, length: 1 },
+            { arg: { filename: 'g', path: 'd/f/g.js' }, length: 1 },
+            { arg: { filename: 'index', path: 'd/f/index.js' }, length: 1 }
+        ]);
+    });
+
+    it('stops at indexes when stopAtIndexes option is set.', async () => {
+
+        const calledWith = [];
+
+        const instance = {
+            callThis: function (arg) {
+
+                calledWith.push({ arg, length: arguments.length });
+            }
+        };
+
+        const manifest = [{
+            method: 'callThis',
+            place: 'stop-at-indexes',
+            list: true,
+            recursive: true,
+            stopAtIndexes: true,
+            useFilename: (value, filename, path) => {
+
+                value.filename = filename;
+                value.path = path;
+                return value;
+            }
+        }];
+
+        await using(closetDir, 'instance', manifest)(instance, {});
+
+        expect(calledWith.sort(byArgPath)).to.equal([
+            { arg: { filename: 'a', path: 'a.js' }, length: 1 },
+            { arg: { filename: 'b', path: 'b.js' }, length: 1 },
+            { arg: { filename: 'index', path: 'c/index.js' }, length: 1 },
+            { arg: { filename: 'e', path: 'd/e.js' }, length: 1 },
+            { arg: { filename: 'index', path: 'd/f/index.js' }, length: 1 }
+        ]);
+    });
+
     it('includes ES modules.', async (flags) => {
 
         const calledWith = [];


### PR DESCRIPTION
In order to support ESM `Haute.call()` is now async, and mo-walk is utilized rather than require-directory.  Support has also been added for stopping at index files as described in https://github.com/hapipal/haute-couture/issues/83.  Finally, deps have been updated and node v8 and v10 support is dropped.